### PR TITLE
Use settings constants for processed data paths

### DIFF
--- a/dashboards/app.py
+++ b/dashboards/app.py
@@ -11,8 +11,8 @@ import plotly.express as px
 from plotly.subplots import make_subplots
 import pandas as pd
 import numpy as np
-from pathlib import Path
 import logging
+from config.settings import PROCESSED_DATA_DIR, CURRENT_RACE_INFO, PAST_STARTS_LONG
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)
@@ -50,13 +50,13 @@ FORM_STATE_COLORS = {
 # Load all data
 def load_all_data():
     """Load all analytical data files"""
-    base_path = Path('data/processed')
+    base_path = PROCESSED_DATA_DIR
     
     data = {}
     
     # Core data
-    data['current'] = pd.read_parquet(base_path / 'current_race_info.parquet')
-    data['past'] = pd.read_parquet(base_path / 'past_starts_long_format.parquet')
+    data['current'] = pd.read_parquet(CURRENT_RACE_INFO)
+    data['past'] = pd.read_parquet(PAST_STARTS_LONG)
     
     # Component analyses
     files_to_load = {

--- a/src/transformers/advanced_fitness_metrics.py
+++ b/src/transformers/advanced_fitness_metrics.py
@@ -16,6 +16,12 @@ from datetime import datetime, timedelta
 from pathlib import Path
 import logging
 from typing import Dict, Tuple, Optional
+from config.settings import (
+    PROCESSED_DATA_DIR,
+    CURRENT_RACE_INFO,
+    PAST_STARTS_LONG,
+    WORKOUTS_LONG,
+)
 import warnings
 warnings.filterwarnings('ignore')
 
@@ -691,10 +697,10 @@ def main():
     """Main function to run fitness calculations"""
     
     # Set up paths
-    base_path = Path('data/processed')
-    current_race_path = base_path / 'current_race_info.parquet'
-    past_starts_path = base_path / 'past_starts_long_format.parquet'
-    workouts_path = base_path / 'workouts_long_format.parquet'
+    base_path = PROCESSED_DATA_DIR
+    current_race_path = CURRENT_RACE_INFO
+    past_starts_path = PAST_STARTS_LONG
+    workouts_path = WORKOUTS_LONG
     
     # Check if files exist
     if not current_race_path.exists():

--- a/src/transformers/advanced_pace_projection.py
+++ b/src/transformers/advanced_pace_projection.py
@@ -15,6 +15,7 @@ from datetime import datetime
 from pathlib import Path
 import logging
 from typing import Dict, List, Tuple, Optional
+from config.settings import PROCESSED_DATA_DIR, CURRENT_RACE_INFO, PAST_STARTS_LONG
 from scipy import stats
 import warnings
 warnings.filterwarnings('ignore')
@@ -790,9 +791,9 @@ def main():
     """Main function to run pace analysis"""
     
     # Set up paths
-    base_path = Path('data/processed')
-    current_race_path = base_path / 'current_race_info.parquet'
-    past_starts_path = base_path / 'past_starts_long_format.parquet'
+    base_path = PROCESSED_DATA_DIR
+    current_race_path = CURRENT_RACE_INFO
+    past_starts_path = PAST_STARTS_LONG
     
     # Check if files exist
     for path in [current_race_path, past_starts_path]:

--- a/src/transformers/feature_engineering.py
+++ b/src/transformers/feature_engineering.py
@@ -2,6 +2,11 @@ import pandas as pd
 import numpy as np
 from pathlib import Path
 from typing import Dict, List, Tuple, Optional
+from config.settings import (
+    PROCESSED_DATA_DIR,
+    PAST_STARTS_LONG,
+    PARSED_RACE_DATA,
+)
 import warnings
 from scipy import stats
 from sklearn.preprocessing import StandardScaler
@@ -17,8 +22,8 @@ class HorseRacingFeatureEngineer:
     
     def __init__(self, processed_data_path: Path):
         self.processed_data_path = processed_data_path
-        self.past_starts_path = processed_data_path / "past_starts_long_format.parquet"
-        self.current_race_path = processed_data_path / "parsed_race_data_full.parquet"
+        self.past_starts_path = processed_data_path / PAST_STARTS_LONG.name
+        self.current_race_path = processed_data_path / PARSED_RACE_DATA.name
         
     def load_data(self) -> Tuple[pd.DataFrame, pd.DataFrame]:
         """Load past starts and current race data."""
@@ -423,7 +428,7 @@ class HorseRacingFeatureEngineer:
 def main():
     """Example usage of the feature engineering system."""
     # Initialize feature engineer
-    processed_data_path = Path("data/processed")
+    processed_data_path = PROCESSED_DATA_DIR
     engineer = HorseRacingFeatureEngineer(processed_data_path)
     
     # Engineer all features

--- a/src/transformers/form_cycle_detector.py
+++ b/src/transformers/form_cycle_detector.py
@@ -16,6 +16,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 import logging
 from typing import Dict, List, Tuple, Optional
+from config.settings import PROCESSED_DATA_DIR, CURRENT_RACE_INFO, PAST_STARTS_LONG
 from scipy import stats
 from scipy.signal import find_peaks
 import warnings
@@ -964,9 +965,9 @@ def main():
     """Main function to run form cycle detection"""
     
     # Set up paths
-    base_path = Path('data/processed')
-    current_race_path = base_path / 'current_race_info.parquet'
-    past_starts_path = base_path / 'past_starts_long_format.parquet'
+    base_path = PROCESSED_DATA_DIR
+    current_race_path = CURRENT_RACE_INFO
+    past_starts_path = PAST_STARTS_LONG
     
     # Check if files exist
     for path in [current_race_path, past_starts_path]:

--- a/src/transformers/integrated_analytics_system.py
+++ b/src/transformers/integrated_analytics_system.py
@@ -15,6 +15,7 @@ from datetime import datetime
 from pathlib import Path
 import logging
 from typing import Dict, List, Tuple, Optional
+from config.settings import PROCESSED_DATA_DIR, CURRENT_RACE_INFO, PAST_STARTS_LONG
 from sklearn.preprocessing import StandardScaler
 from sklearn.cluster import KMeans
 from sklearn.ensemble import RandomForestRegressor, RandomForestClassifier
@@ -67,7 +68,7 @@ def convert_odds_to_decimal(odds_value):
 class IntegratedAnalyticsSystem:
     """Unified system combining all analytical components"""
     
-    def __init__(self, base_path: str = 'data/processed'):
+    def __init__(self, base_path: Path = PROCESSED_DATA_DIR):
         """
         Initialize with path to processed data
         
@@ -89,8 +90,8 @@ class IntegratedAnalyticsSystem:
         logger.info("Loading all analytical components...")
         
         # Core data
-        self.current_df = pd.read_parquet(self.base_path / 'current_race_info.parquet')
-        self.past_df = pd.read_parquet(self.base_path / 'past_starts_long_format.parquet')
+        self.current_df = pd.read_parquet(CURRENT_RACE_INFO)
+        self.past_df = pd.read_parquet(PAST_STARTS_LONG)
         
         # Component analyses (check if exist)
         components = {
@@ -1231,7 +1232,7 @@ def main():
     integrated_report = analytics.generate_integrated_report()
     
     # Save results
-    output_path = Path('data/processed/integrated_analytics_report.parquet')
+    output_path = PROCESSED_DATA_DIR / 'integrated_analytics_report.parquet'
     integrated_report.to_parquet(output_path, index=False)
     logger.info(f"Saved integrated report to {output_path}")
     
@@ -1272,7 +1273,7 @@ def main():
                   f"{horse['key_angles']}")
     
     # Save summary CSV
-    summary_path = Path('data/processed/integrated_summary.csv')
+    summary_path = PROCESSED_DATA_DIR / 'integrated_summary.csv'
     summary_cols = [
         'race', 'horse_name', 'post_position', 'morn_line_odds_if_available',
         'final_rating', 'overall_rank', 'integrated_fitness_score',

--- a/src/transformers/multi_dimensional_class_assessment.py
+++ b/src/transformers/multi_dimensional_class_assessment.py
@@ -15,6 +15,7 @@ from datetime import datetime
 from pathlib import Path
 import logging
 from typing import Dict, List, Tuple, Optional
+from config.settings import PROCESSED_DATA_DIR, CURRENT_RACE_INFO, PAST_STARTS_LONG
 from scipy import stats
 import re
 import warnings
@@ -725,9 +726,9 @@ def main():
     """Main function to run class assessment"""
     
     # Set up paths
-    base_path = Path('data/processed')
-    current_race_path = base_path / 'current_race_info.parquet'
-    past_starts_path = base_path / 'past_starts_long_format.parquet'
+    base_path = PROCESSED_DATA_DIR
+    current_race_path = CURRENT_RACE_INFO
+    past_starts_path = PAST_STARTS_LONG
     
     # Check if files exist
     for path in [current_race_path, past_starts_path]:

--- a/src/transformers/sophisticated_workout_analysis.py
+++ b/src/transformers/sophisticated_workout_analysis.py
@@ -15,6 +15,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 import logging
 from typing import Dict, List, Tuple, Optional
+from config.settings import PROCESSED_DATA_DIR, CURRENT_RACE_INFO, PAST_STARTS_LONG, WORKOUTS_LONG
 import warnings
 warnings.filterwarnings('ignore')
 
@@ -372,10 +373,10 @@ def main():
     """Main function to run workout analysis"""
     
     # Set up paths
-    base_path = Path('data/processed')
-    workouts_path = base_path / 'workouts_long_format.parquet'
-    current_race_path = base_path / 'current_race_info.parquet'
-    past_starts_path = base_path / 'past_starts_long_format.parquet'
+    base_path = PROCESSED_DATA_DIR
+    workouts_path = WORKOUTS_LONG
+    current_race_path = CURRENT_RACE_INFO
+    past_starts_path = PAST_STARTS_LONG
     
     # Check if files exist
     for path in [workouts_path, current_race_path, past_starts_path]:


### PR DESCRIPTION
## Summary
- centralize references to processed data in config
- replace hard-coded paths across dashboards and transformer modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68407c053c108325ae6f695dbbeb49f7