### PR TITLE
Add long format wrapper and update pipeline

### DIFF
--- a/horse_racing/parsers/bris_spec_new.py
+++ b/horse_racing/parsers/bris_spec_new.py
@@ -13,22 +13,26 @@ import numpy as np
 from pathlib import Path
 from typing import List, Dict, Tuple, Any, Final, Optional, Set
 import re # For parsing bris_dict.txt
-import logging # Import logging
+import logging  # Import logging
 
-# --- Global Path Configurations (derived from script location) ---
+from config.settings import (
+    BRIS_SPEC_CACHE,
+    BRIS_DICT,
+    PARSED_RACE_DATA,
+    PROCESSED_DATA_DIR,
+    CACHE_DIR,
+)
+# --- Global Path Configurations ---
 SCRIPT_DIR_BRIS: Final[Path] = Path(__file__).parent.resolve()
-PROJECT_ROOT_BRIS: Final[Path] = SCRIPT_DIR_BRIS.parent.parent # Assumes src/parsers structure
 
 SPEC_CACHE_FILENAME: Final[str] = "bris_spec.pkl"
 BRIS_DICT_FILENAME: Final[str] = "bris_dict.txt"
-# Default DRF if run directly and no argument is passed, can be overridden by main's argument
-# RACE_DATA_FILENAME_DEFAULT: Final[str] = "PIM0509.DRF" 
 
-SPEC_CACHE_FILE_PATH_BRIS: Final[Path] = PROJECT_ROOT_BRIS / "data" / "cache" / SPEC_CACHE_FILENAME
-BRIS_DICT_FILE_PATH_BRIS: Final[Path] = PROJECT_ROOT_BRIS / "data" / "raw" / BRIS_DICT_FILENAME
+SPEC_CACHE_FILE_PATH_BRIS: Final[Path] = BRIS_SPEC_CACHE
+BRIS_DICT_FILE_PATH_BRIS: Final[Path] = BRIS_DICT
 
 OUTPUT_PARQUET_FILENAME: Final[str] = "parsed_race_data_full.parquet"
-OUTPUT_PARQUET_FILE_PATH_BRIS: Final[Path] = PROJECT_ROOT_BRIS / "data" / "processed" / OUTPUT_PARQUET_FILENAME
+OUTPUT_PARQUET_FILE_PATH_BRIS: Final[Path] = PARSED_RACE_DATA
 
 # --- Helper Functions (load_specification_cache, parse_bris_dict_types, etc. remain the same) ---
 def load_specification_cache(spec_cache_path: Path) -> Optional[pd.DataFrame]:
@@ -173,8 +177,8 @@ def main(drf_file_path_arg: Optional[Path] = None):
     logger = logging.getLogger(__name__) # Ensures this main function uses logging
 
     # Ensure parent directories for output exist (moved from global scope for clarity)
-    (PROJECT_ROOT_BRIS / "data" / "processed").mkdir(parents=True, exist_ok=True)
-    (PROJECT_ROOT_BRIS / "data" / "cache").mkdir(parents=True, exist_ok=True) # Cache dir might be for reading too
+    PROCESSED_DATA_DIR.mkdir(parents=True, exist_ok=True)
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
 
     logger.info("--- bris_spec_new.main() starting ---")
 

--- a/horse_racing/transformers/simple_pace.py
+++ b/horse_racing/transformers/simple_pace.py
@@ -19,6 +19,8 @@ from sklearn.cluster import DBSCAN, KMeans
 from sklearn.preprocessing import StandardScaler
 from scipy import stats
 
+from config.settings import PROCESSED_DATA_DIR, PAST_STARTS_LONG, CURRENT_RACE_INFO
+
 # Setup logging
 logging.basicConfig(
     level=logging.INFO,
@@ -26,14 +28,12 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-# Setup paths
-# simple_pace.py is in src/transformers/, so we need to go up 3 levels to reach project root
-PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
-DATA_DIR = PROJECT_ROOT / 'data' / 'processed'
+# Setup paths derived from project settings
+DATA_DIR = PROCESSED_DATA_DIR
 
 # File paths
-PAST_STARTS_FILE = DATA_DIR / 'past_starts_long_format.parquet'
-CURRENT_RACE_FILE = DATA_DIR / 'current_race_info.parquet'
+PAST_STARTS_FILE = PAST_STARTS_LONG
+CURRENT_RACE_FILE = CURRENT_RACE_INFO
 
 # Column mappings
 PAST_COLUMNS = {

--- a/horse_racing/transformers/transform_long_format.py
+++ b/horse_racing/transformers/transform_long_format.py
@@ -1,0 +1,13 @@
+from horse_racing.transformers.transform_workouts import main as transform_workouts
+from horse_racing.transformers.transform_past_starts import main as transform_past_starts
+
+__all__ = ["main"]
+
+def main():
+    """Run both workout and past performance transformations."""
+    transform_workouts()
+    transform_past_starts()
+
+if __name__ == "__main__":
+    main()
+

--- a/horse_racing/transformers/transform_past_starts.py
+++ b/horse_racing/transformers/transform_past_starts.py
@@ -21,24 +21,30 @@ import logging
 import sys
 from pathlib import Path
 from typing import List, Dict, Tuple, Any, Final, Optional, Set
-import numpy as np # For potential numeric cleaning
+import numpy as np  # For potential numeric cleaning
+
+from config.settings import (
+    PARSED_RACE_DATA,
+    BRIS_SPEC_CACHE,
+    PAST_STARTS_LONG,
+)
+from horse_racing.utils.path_utils import get_project_root
 
 # --- Configuration ---
 
-# 1. Define paths relative to the script location
-SCRIPT_DIR: Final[Path] = Path(__file__).parent.resolve()
-PROJECT_ROOT: Final[Path] = SCRIPT_DIR.parent.parent    # .../horse_racing_project/
+# 1. Paths and filenames derived from project settings
+PROJECT_ROOT: Final[Path] = get_project_root()
 
 # 2. Input files
 WIDE_DATA_PARQUET_FILENAME: Final[str] = "parsed_race_data_full.parquet"
 SPEC_CACHE_FILENAME: Final[str] = "bris_spec.pkl"
 
-WIDE_DATA_FILE_PATH: Final[Path] = PROJECT_ROOT / "data" / "processed" / WIDE_DATA_PARQUET_FILENAME
-SPEC_CACHE_FILE_PATH: Final[Path] = PROJECT_ROOT / "data" / "cache" / SPEC_CACHE_FILENAME
+WIDE_DATA_FILE_PATH: Final[Path] = PARSED_RACE_DATA
+SPEC_CACHE_FILE_PATH: Final[Path] = BRIS_SPEC_CACHE
 
 # 3. Output file for the transformed "long" past performance data
 LONG_PAST_STARTS_FILENAME: Final[str] = "past_starts_long_format.parquet"
-LONG_PAST_STARTS_FILE_PATH: Final[Path] = PROJECT_ROOT / "data" / "processed" / LONG_PAST_STARTS_FILENAME
+LONG_PAST_STARTS_FILE_PATH: Final[Path] = PAST_STARTS_LONG
 
 # 4. Define ID variables: Columns identifying the *current* horse/race entry.
 #    *** Based on your confirmation ***

--- a/horse_racing/transformers/transform_workouts.py
+++ b/horse_racing/transformers/transform_workouts.py
@@ -22,24 +22,30 @@ import logging
 import sys
 from pathlib import Path
 from typing import List, Dict, Tuple, Any, Final, Optional, Set
-import numpy as np # For potential numeric cleaning
+import numpy as np  # For potential numeric cleaning
+
+from config.settings import (
+    PARSED_RACE_DATA,
+    BRIS_SPEC_CACHE,
+    WORKOUTS_LONG,
+)
+from horse_racing.utils.path_utils import get_project_root
 
 # --- Configuration ---
 
-# 1. Define paths relative to the script location
-SCRIPT_DIR: Final[Path] = Path(__file__).parent.resolve()
-PROJECT_ROOT: Final[Path] = SCRIPT_DIR.parent.parent    # .../horse_racing_project/
+# 1. Paths and filenames derived from project settings
+PROJECT_ROOT: Final[Path] = get_project_root()
 
 # 2. Input files
 WIDE_DATA_PARQUET_FILENAME: Final[str] = "parsed_race_data_full.parquet"
 SPEC_CACHE_FILENAME: Final[str] = "bris_spec.pkl"
 
-WIDE_DATA_FILE_PATH: Final[Path] = PROJECT_ROOT / "data" / "processed" / WIDE_DATA_PARQUET_FILENAME
-SPEC_CACHE_FILE_PATH: Final[Path] = PROJECT_ROOT / "data" / "cache" / SPEC_CACHE_FILENAME
+WIDE_DATA_FILE_PATH: Final[Path] = PARSED_RACE_DATA
+SPEC_CACHE_FILE_PATH: Final[Path] = BRIS_SPEC_CACHE
 
 # 3. Output file for the transformed "long" workout data
 LONG_WORKOUTS_FILENAME: Final[str] = "workouts_long_format.parquet"
-LONG_WORKOUTS_FILE_PATH: Final[Path] = PROJECT_ROOT / "data" / "processed" / LONG_WORKOUTS_FILENAME
+LONG_WORKOUTS_FILE_PATH: Final[Path] = WORKOUTS_LONG
 
 # 4. Define ID variables: Columns identifying the *current* horse/race entry.
 #    *** Updated based on your confirmation ***

--- a/horse_racing/utils/__init__.py
+++ b/horse_racing/utils/__init__.py
@@ -1,0 +1,17 @@
+"""Utility helpers for the horse_racing package."""
+
+from .path_utils import (
+    get_project_root,
+    get_data_dir,
+    get_raw_dir,
+    get_processed_dir,
+    get_cache_dir,
+)
+
+__all__ = [
+    "get_project_root",
+    "get_data_dir",
+    "get_raw_dir",
+    "get_processed_dir",
+    "get_cache_dir",
+]

--- a/horse_racing/utils/path_utils.py
+++ b/horse_racing/utils/path_utils.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+from config import settings
+
+__all__ = [
+    "get_project_root",
+    "get_data_dir",
+    "get_raw_dir",
+    "get_processed_dir",
+    "get_cache_dir",
+]
+
+
+def get_project_root() -> Path:
+    """Return the root directory of the project."""
+    return settings.BASE_DIR
+
+
+def get_data_dir() -> Path:
+    """Return the top-level data directory."""
+    return settings.DATA_DIR
+
+
+def get_raw_dir() -> Path:
+    """Return the directory containing raw data files."""
+    return settings.RAW_DATA_DIR
+
+
+def get_processed_dir() -> Path:
+    """Return the directory for processed data files."""
+    return settings.PROCESSED_DATA_DIR
+
+
+def get_cache_dir() -> Path:
+    """Return the directory used for cached data."""
+    return settings.CACHE_DIR

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -41,8 +41,7 @@ try:
     from horse_racing.parsers.bris_spec_new import main as parse_bris_main
 
     from horse_racing.transformers.current_race_info import main as create_current_info_main
-    from horse_racing.transformers.transform_workouts import main as transform_workouts_main
-    from horse_racing.transformers.transform_past_starts import main as transform_past_starts_main
+    from horse_racing.transformers.transform_long_format import main as transform_long_format_main
     from horse_racing.transformers.feature_engineering import main as engineer_features_main
 except ImportError as e:
     print(f"Error importing modules: {e}")
@@ -118,13 +117,9 @@ def run_complete_pipeline():
         create_current_info_main()
         logger.info("--- Step 2: Creating current race info completed ---")
 
-        logger.info("--- Step 3: Transforming workouts ---")
-        transform_workouts_main()
-        logger.info("--- Step 3: Transforming workouts completed ---")
-
-        logger.info("--- Step 4: Transforming past starts ---")
-        transform_past_starts_main()
-        logger.info("--- Step 4: Transforming past starts completed ---")
+        logger.info("--- Step 3: Transforming long format data ---")
+        transform_long_format_main()
+        logger.info("--- Step 3: Transformations completed ---")
 
         logger.info("--- Step 5: Engineering features ---")
         engineer_features_main()


### PR DESCRIPTION
## Summary
- add simple `transform_long_format` wrapper that runs both workout and past-start transformers
- expose path utilities with trailing newline fix
- update pipeline to use new long-format transformer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68420995dd388325bba7fe93afdfd5e9