### PR TITLE
Refactor pipeline to use shared long-format transformer

### DIFF
--- a/horse_racing/transformers/long_format_transformer.py
+++ b/horse_racing/transformers/long_format_transformer.py
@@ -1,0 +1,14 @@
+from .transform_workouts import main as _transform_workouts_main
+from .transform_past_starts import main as _transform_past_starts_main
+
+
+def transform_workouts():
+    """Wrapper to generate long-format workouts file."""
+    _transform_workouts_main()
+
+
+def transform_past_starts():
+    """Wrapper to generate long-format past starts file."""
+    _transform_past_starts_main()
+
+__all__ = ["transform_workouts", "transform_past_starts"]

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -41,8 +41,10 @@ try:
     from horse_racing.parsers.bris_spec_new import main as parse_bris_main
 
     from horse_racing.transformers.current_race_info import main as create_current_info_main
-    from horse_racing.transformers.transform_workouts import main as transform_workouts_main
-    from horse_racing.transformers.transform_past_starts import main as transform_past_starts_main
+    from horse_racing.transformers.long_format_transformer import (
+        transform_workouts,
+        transform_past_starts,
+    )
     from horse_racing.transformers.feature_engineering import main as engineer_features_main
 except ImportError as e:
     print(f"Error importing modules: {e}")
@@ -119,11 +121,11 @@ def run_complete_pipeline():
         logger.info("--- Step 2: Creating current race info completed ---")
 
         logger.info("--- Step 3: Transforming workouts ---")
-        transform_workouts_main()
+        transform_workouts()
         logger.info("--- Step 3: Transforming workouts completed ---")
 
         logger.info("--- Step 4: Transforming past starts ---")
-        transform_past_starts_main()
+        transform_past_starts()
         logger.info("--- Step 4: Transforming past starts completed ---")
 
         logger.info("--- Step 5: Engineering features ---")


### PR DESCRIPTION
## Summary
- add a `long_format_transformer` module exposing `transform_workouts` and `transform_past_starts`
- update `run_pipeline` to use these helper functions

## Testing
- `python -m dashboards.app` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_6842099796988325b052f6e2a5eea79b