### PR TITLE
Centralize path management

### DIFF
--- a/horse_racing/parsers/bris_spec_new.py
+++ b/horse_racing/parsers/bris_spec_new.py
@@ -12,23 +12,23 @@ import pandas as pd
 import numpy as np
 from pathlib import Path
 from typing import List, Dict, Tuple, Any, Final, Optional, Set
-import re # For parsing bris_dict.txt
-import logging # Import logging
+import re  # For parsing bris_dict.txt
+import logging  # Import logging
 
-# --- Global Path Configurations (derived from script location) ---
-SCRIPT_DIR_BRIS: Final[Path] = Path(__file__).parent.resolve()
-PROJECT_ROOT_BRIS: Final[Path] = SCRIPT_DIR_BRIS.parent.parent # Assumes src/parsers structure
+from config.settings import (
+    BRIS_SPEC_CACHE,
+    BRIS_DICT,
+    PARSED_RACE_DATA,
+    PROCESSED_DATA_DIR,
+    CACHE_DIR,
+)
 
-SPEC_CACHE_FILENAME: Final[str] = "bris_spec.pkl"
-BRIS_DICT_FILENAME: Final[str] = "bris_dict.txt"
 # Default DRF if run directly and no argument is passed, can be overridden by main's argument
-# RACE_DATA_FILENAME_DEFAULT: Final[str] = "PIM0509.DRF" 
+# RACE_DATA_FILENAME_DEFAULT: Final[str] = "PIM0509.DRF"
 
-SPEC_CACHE_FILE_PATH_BRIS: Final[Path] = PROJECT_ROOT_BRIS / "data" / "cache" / SPEC_CACHE_FILENAME
-BRIS_DICT_FILE_PATH_BRIS: Final[Path] = PROJECT_ROOT_BRIS / "data" / "raw" / BRIS_DICT_FILENAME
-
-OUTPUT_PARQUET_FILENAME: Final[str] = "parsed_race_data_full.parquet"
-OUTPUT_PARQUET_FILE_PATH_BRIS: Final[Path] = PROJECT_ROOT_BRIS / "data" / "processed" / OUTPUT_PARQUET_FILENAME
+SPEC_CACHE_FILE_PATH_BRIS: Final[Path] = BRIS_SPEC_CACHE
+BRIS_DICT_FILE_PATH_BRIS: Final[Path] = BRIS_DICT
+OUTPUT_PARQUET_FILE_PATH_BRIS: Final[Path] = PARSED_RACE_DATA
 
 # --- Helper Functions (load_specification_cache, parse_bris_dict_types, etc. remain the same) ---
 def load_specification_cache(spec_cache_path: Path) -> Optional[pd.DataFrame]:
@@ -173,8 +173,8 @@ def main(drf_file_path_arg: Optional[Path] = None):
     logger = logging.getLogger(__name__) # Ensures this main function uses logging
 
     # Ensure parent directories for output exist (moved from global scope for clarity)
-    (PROJECT_ROOT_BRIS / "data" / "processed").mkdir(parents=True, exist_ok=True)
-    (PROJECT_ROOT_BRIS / "data" / "cache").mkdir(parents=True, exist_ok=True) # Cache dir might be for reading too
+    PROCESSED_DATA_DIR.mkdir(parents=True, exist_ok=True)
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)  # Cache dir might be for reading too
 
     logger.info("--- bris_spec_new.main() starting ---")
 

--- a/horse_racing/transformers/current_race_info.py
+++ b/horse_racing/transformers/current_race_info.py
@@ -16,21 +16,13 @@ import pandas as pd
 import numpy as np
 from pathlib import Path
 from typing import List, Final, Optional
-import logging # Import logging
+import logging  # Import logging
 
-# --- Configuration ---
-# These paths correctly point to your data/processed/ directory
-SCRIPT_DIR_CURRENT_INFO: Final[Path] = Path(__file__).parent.resolve()
-PROJECT_ROOT_CURRENT_INFO: Final[Path] = SCRIPT_DIR_CURRENT_INFO.parent.parent
-PROCESSED_DATA_DIR_CURRENT_INFO: Final[Path] = PROJECT_ROOT_CURRENT_INFO / "data" / "processed"
-PROCESSED_DATA_DIR_CURRENT_INFO.mkdir(parents=True, exist_ok=True)
+from config.settings import PARSED_RACE_DATA, CURRENT_RACE_INFO, PROCESSED_DATA_DIR
 
-
-WIDE_DATA_PARQUET_FILENAME: Final[str] = "parsed_race_data_full.parquet"
-WIDE_DATA_FILE_PATH: Final[Path] = PROCESSED_DATA_DIR_CURRENT_INFO / WIDE_DATA_PARQUET_FILENAME
-
-CURRENT_INFO_FILENAME: Final[str] = "current_race_info.parquet"
-CURRENT_INFO_FILE_PATH: Final[Path] = PROCESSED_DATA_DIR_CURRENT_INFO / CURRENT_INFO_FILENAME
+# --- Centralized Path Configuration ---
+WIDE_DATA_FILE_PATH: Final[Path] = PARSED_RACE_DATA
+CURRENT_INFO_FILE_PATH: Final[Path] = CURRENT_RACE_INFO
 
 # COLUMNS_TO_DROP and record_groups are defined as before...
 COLUMNS_TO_DROP: Final[List[str]] = [

--- a/horse_racing/transformers/simple_pace.py
+++ b/horse_racing/transformers/simple_pace.py
@@ -19,6 +19,8 @@ from sklearn.cluster import DBSCAN, KMeans
 from sklearn.preprocessing import StandardScaler
 from scipy import stats
 
+from config.settings import PROCESSED_DATA_DIR, PAST_STARTS_LONG, CURRENT_RACE_INFO
+
 # Setup logging
 logging.basicConfig(
     level=logging.INFO,
@@ -26,14 +28,9 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-# Setup paths
-# simple_pace.py is in src/transformers/, so we need to go up 3 levels to reach project root
-PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
-DATA_DIR = PROJECT_ROOT / 'data' / 'processed'
-
-# File paths
-PAST_STARTS_FILE = DATA_DIR / 'past_starts_long_format.parquet'
-CURRENT_RACE_FILE = DATA_DIR / 'current_race_info.parquet'
+# File paths from centralized settings
+PAST_STARTS_FILE = PAST_STARTS_LONG
+CURRENT_RACE_FILE = CURRENT_RACE_INFO
 
 # Column mappings
 PAST_COLUMNS = {

--- a/horse_racing/transformers/simple_stats.py
+++ b/horse_racing/transformers/simple_stats.py
@@ -5,14 +5,10 @@ import sys
 from pathlib import Path
 from typing import List, Final, Optional
 
-# --- Define standardized paths ---
-SCRIPT_DIR: Path = Path(__file__).parent.resolve() # .../src/transformers/
-PROJECT_ROOT: Path = SCRIPT_DIR.parent.parent    # .../horse_racing_project/
-PROCESSED_DATA_DIR: Path = PROJECT_ROOT / "data" / "processed"
-PROCESSED_DATA_DIR.mkdir(parents=True, exist_ok=True) # Ensure directory exists
+from config.settings import PARSED_RACE_DATA, PROCESSED_DATA_DIR
 
-# --- Input file path ---
-INPUT_PARQUET_PATH: Path = PROCESSED_DATA_DIR / "parsed_race_data_full.parquet"
+# --- Input file path from centralized settings ---
+INPUT_PARQUET_PATH: Path = PARSED_RACE_DATA
 
 def compute_fractional_splits(df: pd.DataFrame) -> pd.DataFrame:
     """


### PR DESCRIPTION
## Summary
- update simple_pace.py to import data paths from `config.settings`
- update simple_stats.py to use centralized `PARSED_RACE_DATA`
- update current_race_info.py to rely on global settings
- update bris_spec_new.py to pull paths from the config

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68420c9e53248325bfaa23e721cb0a16