### PR TITLE
Move simple stats helpers

### DIFF
--- a/horse_racing/transformers/long_format_transformer.py
+++ b/horse_racing/transformers/long_format_transformer.py
@@ -525,6 +525,126 @@ def add_class_and_odds_metrics(df: pd.DataFrame) -> pd.DataFrame:
     out["odds_last_1"] = out.groupby(group_cols)["pp_odds"].transform(lambda s: s.iloc[-1])
     return out
 
+
+def compute_fractional_splits(df: pd.DataFrame) -> pd.DataFrame:
+    """Build fractional split columns for races 1–10 from cumulative fractions."""
+    splits = {}
+    for i in range(1, 11):
+        c2, c4, c6 = (
+            f"2f_fraction_if_any_{i}",
+            f"4f_fraction_if_any_{i}",
+            f"6f_fraction_if_any_{i}",
+        )
+        c8, c10, c12 = (
+            f"8f_fraction_if_any_{i}",
+            f"10f_fraction_if_any_{i}",
+            f"12f_fraction_if_any_{i}",
+        )
+        c5, c7, c9 = (
+            f"5f_fraction_if_any_{i}",
+            f"7f_fraction_if_any_{i}",
+            f"9f_fraction_if_any_{i}",
+        )
+
+        for col in (c2, c4, c6, c8, c10, c12, c5, c7, c9):
+            if col in df.columns:
+                df[col] = pd.to_numeric(df[col], errors="coerce")
+
+        if c2 in df:
+            splits[f"fraction_1_{i}"] = df[c2]
+        if c2 in df and c4 in df:
+            splits[f"fraction_2_{i}"] = df[c4] - df[c2]
+        if c4 in df and c6 in df:
+            splits[f"fraction_3_{i}"] = df[c6] - df[c4]
+        if c6 in df and c8 in df:
+            splits[f"fraction_4_{i}"] = df[c8] - df[c6]
+        if c8 in df and c10 in df:
+            splits[f"fraction_5_{i}"] = df[c10] - df[c8]
+        if c10 in df and c12 in df:
+            splits[f"fraction_6_{i}"] = df[c12] - df[c10]
+
+        if c5 in df and c4 in df:
+            splits[f"fraction_5f_{i}"] = df[c5] - df[c4]
+        if c7 in df and c6 in df:
+            splits[f"fraction_7f_{i}"] = df[c7] - df[c6]
+        if c9 in df and c8 in df:
+            splits[f"fraction_9f_{i}"] = df[c9] - df[c8]
+
+    return pd.DataFrame(splits, index=df.index)
+
+
+def calculate_record_statistics(df: pd.DataFrame) -> pd.DataFrame:
+    """Return a DataFrame with win %, ITM %, and earnings per start metrics."""
+    logger = logging.getLogger(__name__)
+    record_groups = {
+        "distance": ("starts_pos_65", "wins_pos_66", "places_pos_67", "shows_pos_68", "earnings_pos_69"),
+        "track": ("starts_pos_70", "wins_pos_71", "places_pos_72", "shows_pos_73", "earnings_pos_74"),
+        "turf": ("starts_pos_75", "wins_pos_76", "places_pos_77", "shows_pos_78", "earnings_pos_79"),
+        "mud": ("starts_pos_80", "wins_pos_81", "places_pos_82", "shows_pos_83", "earnings_pos_84"),
+        "current_year": ("starts_pos_86", "wins_pos_87", "places_pos_88", "shows_pos_89", "earnings_pos_90"),
+        "previous_year": ("starts_pos_92", "wins_pos_93", "places_pos_94", "shows_pos_95", "earnings_pos_96"),
+        "lifetime": ("starts_pos_97", "wins_pos_98", "places_pos_99", "shows_pos_100", "earnings_pos_101"),
+    }
+
+    for name, (col_start, col_win, col_place, col_show, col_earn) in record_groups.items():
+        missing_cols = [c for c in [col_start, col_win, col_place, col_show, col_earn] if c not in df.columns]
+        if missing_cols:
+            logger.warning("Missing columns for %s record group: %s", name, missing_cols)
+            continue
+        starts = df[col_start].replace({0: np.nan})
+        df[f"{name}_win_pct"] = df[col_win] / starts
+        df[f"{name}_itm_pct"] = (df[col_win] + df[col_place] + df[col_show]) / starts
+        df[f"{name}_earnings_per_start"] = df[col_earn] / starts
+
+    record_groups_list = ["distance", "track", "turf", "mud", "current_year", "previous_year", "lifetime"]
+    metrics: List[str] = []
+    for name in record_groups_list:
+        metrics += [f"{name}_win_pct", f"{name}_itm_pct", f"{name}_earnings_per_start"]
+
+    base_cols = ["race", "post_position", "morn_line_odds_if_available", "horse_name"]
+    available_metrics = [col for col in metrics if col in df.columns]
+    available_base_cols = [col for col in base_cols if col in df.columns]
+    return df[available_base_cols + available_metrics].copy()
+
+
+def calculate_jockey_performance(df: pd.DataFrame) -> pd.DataFrame:
+    """Create a DataFrame summarizing jockey performance statistics."""
+    jockey_cols = [
+        "wins_4_pos_1158",
+        "jockey_sts_current_year",
+        "wins_4_pos_1163",
+        "jockey_sts_previous_year",
+        "jockey_wins_current_meet",
+        "jockey_sts_current_meet",
+        "t_j_combo_wins_meet",
+        "t_j_combo_starts_meet",
+    ]
+
+    for col in jockey_cols:
+        if col in df.columns:
+            df[col] = pd.to_numeric(df[col], errors="coerce")
+
+    jockey_base_cols = ["today_s_jockey", "jockey_1"]
+    available_jockey_base = [col for col in jockey_base_cols if col in df.columns]
+    if not (available_jockey_base and "today_s_jockey" in df.columns):
+        return pd.DataFrame()
+
+    df_jockey = pd.DataFrame({
+        "Jockey": df["today_s_jockey"],
+        "Change": df["today_s_jockey"].eq(df.get("jockey_1", df["today_s_jockey"])).map({True: "N", False: "Y"}),
+    })
+
+    if "wins_4_pos_1158" in df.columns and "jockey_sts_current_year" in df.columns:
+        df_jockey["Win %"] = df["wins_4_pos_1158"] / df["jockey_sts_current_year"]
+    if "wins_4_pos_1163" in df.columns and "jockey_sts_previous_year" in df.columns:
+        df_jockey["Last Yr %"] = df["wins_4_pos_1163"] / df["jockey_sts_previous_year"]
+    if "jockey_wins_current_meet" in df.columns and "jockey_sts_current_meet" in df.columns:
+        df_jockey["Meet"] = df["jockey_wins_current_meet"] / df["jockey_sts_current_meet"]
+    if "t_j_combo_wins_meet" in df.columns and "t_j_combo_starts_meet" in df.columns:
+        df_jockey["T/J"] = df["t_j_combo_wins_meet"] / df["t_j_combo_starts_meet"]
+
+    return df_jockey
+
 # ---------------------------------------------------------------------------
 # High level transformation functions
 


### PR DESCRIPTION
## Summary
- add fractional split, record statistics, and jockey performance helpers to long format transformer

## Testing
- `python -m py_compile horse_racing/transformers/long_format_transformer.py`
- `python -m py_compile horse_racing/transformers/simple_stats.py`
- `python -m py_compile run_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_6842158a86608325a71d4bc52794cafd