### PR TITLE
Fix dropdown visibility

### DIFF
--- a/dashboards/app.py
+++ b/dashboards/app.py
@@ -127,7 +127,8 @@ def get_simple_pace_layout():
                         style={
                             'backgroundColor': COLORS['card_bg'],
                             'color': COLORS['text']
-                        }
+                        },
+                        dropdownClassName="dropdown-options"
                     )
                 ], width=4),
 
@@ -276,7 +277,8 @@ app.layout = html.Div([
                     'display': 'inline-block',
                     'backgroundColor': COLORS['card_bg'],
                     'color': COLORS['text']
-                }
+                },
+                dropdownClassName="dropdown-options"
             )
         ], style={'display': 'inline-block', 'marginRight': '40px'}),
 
@@ -292,7 +294,8 @@ app.layout = html.Div([
                     'display': 'inline-block',
                     'backgroundColor': COLORS['card_bg'],
                     'color': COLORS['text']
-                }
+                },
+                dropdownClassName="dropdown-options"
             )
         ], style={'display': 'inline-block'})
     ], style={'padding': '20px', 'backgroundColor': COLORS['background']}),

--- a/dashboards/assets/dropdown.css
+++ b/dashboards/assets/dropdown.css
@@ -1,0 +1,7 @@
+.dropdown-options .Select-menu-outer {
+    background-color: #ffffff;
+}
+
+.dropdown-options .Select-option {
+    color: #000000;
+}


### PR DESCRIPTION
## Summary
- add dropdown options CSS style to ensure text is dark on a light menu
- apply dropdownClassName for all dropdown components in the dashboard app

## Testing
- `python -m py_compile dashboards/app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68438e2c164483259586cabe75f478cc