### PR TITLE
Fix invalid dropdown property

### DIFF
--- a/dashboards/app.py
+++ b/dashboards/app.py
@@ -123,12 +123,11 @@ def get_simple_pace_layout():
                         id='race-dropdown',
                         options=[],
                         value=None,
-                        className="mb-3",
+                        className="mb-3 dropdown-options",
                         style={
                             'backgroundColor': COLORS['card_bg'],
                             'color': COLORS['text']
-                        },
-                        dropdownClassName="dropdown-options"
+                        }
                     )
                 ], width=4),
 
@@ -272,13 +271,13 @@ app.layout = html.Div([
                 id='race-selector',
                 options=RACE_OPTIONS,
                 value=RACE_OPTIONS[0]['value'] if RACE_OPTIONS else None,
+                className="dropdown-options",
                 style={
                     'width': '200px',
                     'display': 'inline-block',
                     'backgroundColor': COLORS['card_bg'],
                     'color': COLORS['text']
-                },
-                dropdownClassName="dropdown-options"
+                }
             )
         ], style={'display': 'inline-block', 'marginRight': '40px'}),
 
@@ -289,13 +288,13 @@ app.layout = html.Div([
                 options=[],
                 value=[],
                 multi=True,
+                className="dropdown-options",
                 style={
                     'width': '200px',
                     'display': 'inline-block',
                     'backgroundColor': COLORS['card_bg'],
                     'color': COLORS['text']
-                },
-                dropdownClassName="dropdown-options"
+                }
             )
         ], style={'display': 'inline-block'})
     ], style={'padding': '20px', 'backgroundColor': COLORS['background']}),


### PR DESCRIPTION
## Summary
- remove `dropdownClassName` argument from dash dcc.Dropdown components
- use `className` instead

## Testing
- `python -m py_compile dashboards/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68443a06c1708325a41b9c36d6b28f47