### PR TITLE
Handle missing run style data

### DIFF
--- a/horse_racing/transformers/simple_pace.py
+++ b/horse_racing/transformers/simple_pace.py
@@ -440,12 +440,15 @@ class PaceAnalyzer:
             
             # Lead-Abundance Flag for this specific race
             if 'bris_run_style_designation' in results.columns and 'quirin_style_speed_points' in results.columns:
-                lead_horses_in_race = results[
-                    race_mask &
-                    ((results['bris_run_style_designation'] == 'E') | 
-                     (results['bris_run_style_designation'] == 'E/P')) & 
-                    (results['quirin_style_speed_points'] >= 6)
-                ]
+                run_styles = results.loc[race_mask, 'bris_run_style_designation']
+                run_styles = run_styles.fillna('').astype(str).str.upper()
+
+                sp = pd.to_numeric(
+                    results.loc[race_mask, 'quirin_style_speed_points'], errors='coerce'
+                ).fillna(0)
+
+                lead_mask = run_styles.isin(['E', 'E/P']) & (sp >= 6)
+                lead_horses_in_race = results.loc[race_mask][lead_mask]
                 results.loc[race_mask, 'lead_abundance_flag'] = len(lead_horses_in_race)
             else:
                 results.loc[race_mask, 'lead_abundance_flag'] = 0


### PR DESCRIPTION
## Summary
- robustify `lead_abundance_flag` calculation in simple pace analyzer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684465a71ccc8325806a465bc166e086